### PR TITLE
Fix JobInfo incorrect hasExited() value

### DIFF
--- a/src/main/java/org/biouno/drmaa_pbs/SessionImpl.java
+++ b/src/main/java/org/biouno/drmaa_pbs/SessionImpl.java
@@ -264,7 +264,7 @@ public class SessionImpl implements Session {
     }
 
     private JobInfo jobToJobInfo(Job job) {
-        return new JobInfoImpl(job.getId(), job.getResourcesUsed(), job.getState() == "F" || job.getState() == "X",
+        return new JobInfoImpl(job.getId(), job.getResourcesUsed(), job.getState().equals("F") || job.getState().equals("X"),
                 job.getExitStatus(), "", // TODO
                 false, // TODO
                 false, // TODO


### PR DESCRIPTION
This one's my bad.
Unlike Scala, Java's string comparison should use .equals() *not* ==
Not sure why it worked for me before..